### PR TITLE
Embed portable Tesseract and PDF OCR fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # expe
+
+## OCR portátil
+
+Incluir un Tesseract portátil con la siguiente estructura:
+
+```
+tesseract/
+  tesseract.exe
+  *.dll
+  tessdata/
+    spa.traineddata
+    eng.traineddata
+```
+
+### Empaquetado
+
+Ejemplo con PyInstaller:
+
+```
+pyinstaller --noconfirm --onefile expediente.py ^
+  --add-data "tesseract;tesseract" ^
+  --add-data "ms-playwright;ms-playwright"
+```


### PR DESCRIPTION
## Summary
- use local tesseract in `_prepare_tesseract_env`
- generate searchable PDFs via pdfium + pytesseract without CLI
- log embedded tesseract path in OCR preflight and document portable layout

## Testing
- `python -m py_compile expediente.py`

------
https://chatgpt.com/codex/tasks/task_b_68bbb8a93ebc8322acf71b74eb9b83ea