### PR TITLE
Use Windows WinRT OCR instead of Tesseract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,14 @@
 # expe
 
-## OCR portátil
-
-Incluir un Tesseract portátil con la siguiente estructura:
-
-```
-tesseract/
-  tesseract.exe
-  *.dll
-  tessdata/
-    spa.traineddata
-    eng.traineddata
-```
-
-### Empaquetado
+## Empaquetado
 
 Ejemplo con PyInstaller:
 
 ```
 pyinstaller --noconfirm --onefile expediente.py ^
-  --add-data "tesseract;tesseract" ^
-  --add-data "ms-playwright;ms-playwright"
+  --add-data "ms-playwright;ms-playwright" ^
+  --hidden-import=winrt.windows.media.ocr ^
+  --hidden-import=winrt.windows.graphics.imaging ^
+  --hidden-import=winrt.windows.storage.streams ^
+  --hidden-import=winrt.windows.globalization
 ```


### PR DESCRIPTION
## Summary
- replace Tesseract/Ghostscript OCR pipeline with Windows WinRT OCR using PyMuPDF
- keep _maybe_ocr API and add WinRT helper utilities
- document required WinRT hidden imports for PyInstaller

## Testing
- `python -m py_compile expediente.py`


------
https://chatgpt.com/codex/tasks/task_b_68bbc822c6b4832289b15207156d8fce