### PR TITLE
Add optional final OCR step and drop attachment OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ pyinstaller --noconfirm --onefile expediente.py ^
   --hidden-import=winrt.windows.storage.streams ^
   --hidden-import=winrt.windows.globalization
 ```
+
+## Dependencias
+
+- [ocrmypdf](https://ocrmypdf.readthedocs.io/) (requiere Tesseract)
+
+## Variables de entorno
+
+- `OCR_FINAL_FORCE`: si se establece en `1`/`true`, ejecuta un OCR final sobre el PDF generado usando `ocrmypdf` (300 DPI, `--deskew`, `--rotate-pages`).


### PR DESCRIPTION
## Summary
- stop running OCR on individual attachments
- optionally run a final OCR pass on the merged PDF using `ocrmypdf`
- document the new OCR option and dependency

## Testing
- `python -m py_compile expediente.py`


------
https://chatgpt.com/codex/tasks/task_b_68bbdfbb6428832285a83493ef6f8283