### PR TITLE
Add technical report download and merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # expe
 
+Herramienta para descargar expedientes del SAC, adjuntos e informes técnicos MPF.
+
 ## Empaquetado
 
 Ejemplo con PyInstaller:


### PR DESCRIPTION
## Summary
- download technical reports from Radiografía, capturing movement dates
- merge technical reports into final PDF with headers
- limit downloads to MPF technical reports to avoid unrelated sections
- document that only MPF technical reports are processed

## Testing
- `python -m py_compile expediente.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bf5b1865008322b5216b0053fd0971