### PR TITLE
Fix index links for PDF navigation

### DIFF
--- a/expediente.py
+++ b/expediente.py
@@ -697,7 +697,7 @@ def fusionar_bloques_con_indice(bloques, destino: Path, index_title: str = "INDI
                 link_rect = fitz.Rect(x_left - 2, y - fs, x_right, y + fs)
                 try:
                     idx_page.add_link(
-                        pno=target_page, rect=link_rect, dest=fitz.Point(0, 0)
+                        rect=link_rect, page=target_page, dest=fitz.Point(0, 0)
                     )
                 except Exception:
                     try:


### PR DESCRIPTION
## Summary
- Ensure index entries add clickable links to their respective PDF pages by using the correct `page` parameter when creating links
- Maintain compatibility by falling back to `insert_link` if `add_link` is unavailable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c2f2e667088322a4125cd81f2ffd43