### PR TITLE
Handle rename failure after relinking

### DIFF
--- a/expediente.py
+++ b/expediente.py
@@ -815,7 +815,11 @@ def _relink_indice_con_fitz(pdf_path: Path, items: list[dict],
                 tmp = pdf_path.with_suffix(".tmp.pdf")
                 doc.save(str(tmp), deflate=True)
                 doc.close()
-                tmp.replace(pdf_path)
+                try:
+                    tmp.replace(pdf_path)
+                except PermissionError:
+                    shutil.copyfile(tmp, pdf_path)
+                    tmp.unlink()
             else:
                 doc.close()
                 raise


### PR DESCRIPTION
## Summary
- handle permission error when renaming temporary PDF after relinking

## Testing
- `python -m py_compile expediente.py`


------
https://chatgpt.com/codex/tasks/task_b_68c4797ccdf483228ced0e06b17d3de7