### PR TITLE
Handle PyMuPDF new_page returning None

### DIFF
--- a/expediente.py
+++ b/expediente.py
@@ -667,6 +667,14 @@ def fusionar_bloques_con_indice(bloques, destino: Path, index_title: str = "INDI
                 index_pages = []
                 for i in range(idx_page_count):
                     pg = dst.new_page(pno=1 + i, width=pw, height=ph)
+                    # Algunas versiones de PyMuPDF pueden devolver None o un
+                    # índice entero. Normalizamos para obtener siempre un
+                    # objeto Page válido.
+                    if pg is None:
+                        try:
+                            pg = dst[1 + i]
+                        except Exception:
+                            continue
                     if isinstance(pg, int):
                         pg = dst[pg]
                     index_pages.append(pg)


### PR DESCRIPTION
## Summary
- Normalize index page creation to handle PyMuPDF versions where `new_page` returns `None` or an integer.

## Testing
- `python -m py_compile expediente.py`


------
https://chatgpt.com/codex/tasks/task_b_68c4c0ad14dc83228fec7ede934d3fbb